### PR TITLE
New evolutionary algorithms class

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,14 +92,22 @@ for Ruby.
   Feed-forward neural networks for JRuby based on
   [brains](https://github.com/jedld/brains).
 - [neuroevo](https://github.com/giuse/neuroevo) -
-  Pure Ruby evolutional implementation of both feed-forward and recurrent,
-  fully-connected neural networks (via xNES and SNES).
+  Pure Ruby implementation of both feed-forward and recurrent neural networks
+  (fully connected). Training using neuroevolution (xNES and SNES).
 
 ### Kernel methods
 
 - [rb-libsvm](https://github.com/febeling/rb-libsvm) -
   Support Vector Machines with Ruby and the [LIBSVM](http://www.csie.ntu.edu.tw/~cjlin/libsvm/) library.
   <sup>[[dep: bundled](#bundled)]</sup>
+
+### Evolutionary algorithms
+- [neuroevo](https://github.com/giuse/neuroevo) -
+  Pure Ruby implementation of Natural Evolution Strategy algorithms
+  (black-box optimization), specifically Exponential NES (XNES) and
+  Separable NES (sNES). Application to neural network training (neuroevolution).
+- [simple_ga](https://github.com/giuse/simple_ga) -
+  Simplest Genetic Algorithms implementation in Ruby.
 
 ### Bayesian methods
 - [linnaeus](https://github.com/djcp/linnaeus) -
@@ -237,7 +245,7 @@ section on the [Data Science with Ruby][ds-with-ruby] list.
 - [Wine Clustering](https://github.com/hexgnu/wine_clustering) -
   Wine quality estimations clustered with different algorithms.
 - [simple_ga](https://github.com/giuse/simple_ga) -
-  Basic (working) demo program on Genetic Algorithms in Ruby.
+  Basic (working) demo of Genetic Algorithms in Ruby.
 
 ## Heroku buildpacks
 


### PR DESCRIPTION
Fixed the description on gem `neuroevo` from a neural network perspective.
Added the same gem (duplicate) under the new evolutionary algorithms class.
Reason lies in the gem having double scope, and implementing two distinct ML functionalities.
Same goes also for gem `simple_ga`: while having been written as a demo project, it is one of few pure-ruby (working) implementations based on evolutionary algorithms, and for now I would suggest to help developers finding it through the list. Could be removed as soon as a better/more advanced GA implementation makes it into the list.

Commit message:
Evolutionary Algorithms is a huge field per-se, currently maybe shadowed by Deep Learning but likely to come back in vogue as soon as DL limits are reached. Gem `simple_ga` is mainly a demo program, but constitutes a working and usable implementation of a basic Genetic Algorithm. Gem `neuroevo` should (and likely soon will) be divided in two gems as it provides two distinct functionalities: Neural Networks and Evolutionary Strategies (combined in a neuroevolution framework), so it naturally belongs to two classes (my bad on writing a gem with double responsibilities, but it's code I needed at work, and fast).

I want to contribute to this list and help the maintainers, so:

- [x] I've accepted the terms of the `CC0` License;
- [x] I've added the topic `rubyml` to the contributed repository if appropriate.
