### PR TITLE
Typo: formelly -> formerly

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -414,7 +414,7 @@ section on the [Data Science with Ruby][ds-with-ruby] list.
   General List of NLP related resources (mostly not for Ruby programmers).
 - [Scientific Ruby](http://sciruby.com/) -
   Linear Algebra, Visualization and Scientific Computing for Ruby.
-- [iRuby](https://github.com/SciRuby/iruby) - IRuby kernel for Jupyter (formelly IPython).
+- [iRuby](https://github.com/SciRuby/iruby) - IRuby kernel for Jupyter (formerly IPython).
 - [Kiba](https://github.com/thbar/kiba) -
   Lightweight [ETL](https://en.wikipedia.org/wiki/Extract,_transform,_load) (Extract, Transform, Load) pipeline.
 - [Awesome OCR](https://github.com/kba/awesome-ocr) -


### PR DESCRIPTION
Just a typo @arbox 

I want to contribute to this list and help the maintainers, so:

- [x] I've accepted the terms of the `CC0` License;
- [ ] I've added the topic `rubyml` to the contributed repository if appropriate.
