### PR TITLE
Add `langchain.rb` to the Frameworks list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ programming languages with appropriate bindings for Ruby.
 ### Frameworks
 
 - [LangChain.rb](https://github.com/andreibondarev/langchainrb) -
-  Build ML/AI-supercharged applications with Ruby's LangChain
+  Build ML/AI-supercharged applications with Ruby's LangChain.
 - [weka](https://github.com/paulgoetze/weka-jruby) -
   JRuby bindings for Weka, different ML algorithms implemented through Weka.
 - [ai4r](https://github.com/SergioFierens/ai4r) -

--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,8 @@ programming languages with appropriate bindings for Ruby.
 
 ### Frameworks
 
+- [LangChain.rb](https://github.com/andreibondarev/langchainrb) -
+  Build ML/AI-supercharged applications with Ruby's LangChain
 - [weka](https://github.com/paulgoetze/weka-jruby) -
   JRuby bindings for Weka, different ML algorithms implemented through Weka.
 - [ai4r](https://github.com/SergioFierens/ai4r) -


### PR DESCRIPTION
I want to contribute to this list and help the maintainers, so:

- [x] I've accepted the terms of the `CC0` License;
- [x] I've added the topic `rubyml` to the contributed repository if appropriate.
