### PR TITLE
Add hnwlib.rb and ngt-ruby gems to Vector search

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -195,17 +195,12 @@ programming languages with appropriate bindings for Ruby.
 
 ### Clustering
 
-- [flann](https://github.com/mariusmuja/flann) -
-  Fast Library for Approximate Nearest Neighbors.
-  <sup>[[flann](#flann)]</sup>
 - [kmeans-clusterer](https://github.com/gbuesing/kmeans-clusterer) -
   k-means clustering in Ruby.
 - [k_means](https://github.com/reddavis/K-Means) -
   Attempting to build a fast, memory efficient K-Means program.
 - [knn](https://github.com/reddavis/knn) -
   Simple K Nearest Neighbour Algorithm.
-- [annoy-rb](https://github.com/yoshoku/annoy.rb) -
-  bindings for the [Annoy](https://github.com/spotify/annoy) (Approximate Nearest Neighbors Oh Yeah).
 
 ### Linear classifiers
 
@@ -240,8 +235,14 @@ programming languages with appropriate bindings for Ruby.
 - [lightgbm](https://github.com/ankane/lightgbm) &mdash;
   Ruby bindings for LightGBM.
   <sup>[[dep: LightGBM](#lightgbm)]</sup>
-  
+
 ### Vector search
+
+- [flann](https://github.com/mariusmuja/flann) -
+  Fast Library for Approximate Nearest Neighbors.
+  <sup>[[flann](#flann)]</sup>
+- [annoy-rb](https://github.com/yoshoku/annoy.rb) -
+  bindings for the [Annoy](https://github.com/spotify/annoy) (Approximate Nearest Neighbors Oh Yeah).
 - [milvus](https://github.com/andreibondarev/milvus) &mdash;
   Ruby client for Milvus Vector DB.
 - [pinecone](https://github.com/ScotterC/pinecone) &mdash;

--- a/readme.md
+++ b/readme.md
@@ -239,10 +239,14 @@ programming languages with appropriate bindings for Ruby.
 ### Vector search
 
 - [flann](https://github.com/mariusmuja/flann) -
-  Fast Library for Approximate Nearest Neighbors.
+  Ruby bindings for the [FLANN](https://github.com/flann-lib/flann) (Fast Library for Approximate Nearest Neighbors).
   <sup>[[flann](#flann)]</sup>
 - [annoy-rb](https://github.com/yoshoku/annoy.rb) -
-  bindings for the [Annoy](https://github.com/spotify/annoy) (Approximate Nearest Neighbors Oh Yeah).
+  Ruby bindings for the [Annoy](https://github.com/spotify/annoy) (Approximate Nearest Neighbors Oh Yeah).
+- [hnswlib.rb](https://github.com/yoshoku/hnswlib.rb) -
+  Ruby bindings for the [Hnswlib](https://github.com/nmslib/hnswlib) that implements approximate nearest neighbor search with Hierarchical Navigable Small World graphs.
+- [ngt-ruby](https://github.com/ankane/ngt-ruby) -
+  Ruby bindings for the [NGT](https://github.com/yahoojapan/NGT) (Neighborhood Graph and Tree for Indexing High-dimensional data).
 - [milvus](https://github.com/andreibondarev/milvus) &mdash;
   Ruby client for Milvus Vector DB.
 - [pinecone](https://github.com/ScotterC/pinecone) &mdash;


### PR DESCRIPTION
I would like to add the hnswlib.rb and ngt-ruby gems to the Vector search section. They are ruby bindings for vector search with graph structure.
In addition, I relocated the flann and annoy-rb gems to the Vector search section from the Clustering section. Since they provide vector search functions with tree structure, they are better listed in the Vector search section rather than the Clustering section.

--

I want to contribute to this list and help the maintainers, so:

- [x] I've accepted the terms of the `CC0` License;
- [x] I've added the topic `rubyml` to the contributed repository if appropriate.
